### PR TITLE
chore: add node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,12 +39,16 @@
     "@biomejs/biome": "2.2.5",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/eslint-plugin-query": "^5.91.0",
-    "@types/react": "^18.3.25",
-    "@types/react-dom": "^18.3.7",
+    "@types/node": "^22.18.6",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss": "^3.4.18",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": "22.x"
   }
 }


### PR DESCRIPTION
### TL;DR

Updated React and Node.js dependencies and specified Node.js engine requirements.

### What changed?

- Added `@types/node` dependency (version ^22.18.6)
- Updated React type definitions:
  - `@types/react` from ^18.3.25 to ^19.2.0
  - `@types/react-dom` from ^18.3.7 to ^19.2.0
- Added `engines` field to specify Node.js version requirement (22.x)

### How to test?

1. Run `npm install` to update dependencies
2. Verify the application builds and runs correctly with the updated dependencies
3. Ensure your development environment is using Node.js 22.x

### Why make this change?

This update prepares the codebase for compatibility with the latest versions of React and Node.js. The addition of the Node.js engine specification ensures consistent development environments across the team and prevents potential compatibility issues.