### PR TITLE
draft blog posts

### DIFF
--- a/src/content/posts/astro-theme-toggle-with-page-transitions.mdx
+++ b/src/content/posts/astro-theme-toggle-with-page-transitions.mdx
@@ -4,8 +4,8 @@ author: Jack Watters
 description: "Quick adjustment to an Astro theme toggle when using page transitions."
 pubDate: 2024-06-06
 tags: [astro]
+draft: true
 ---
-
 
 TLDR: Add an event listener for `astro:after-swap` that checks local storage to update the theme.
 
@@ -13,16 +13,18 @@ When working with [Astro](https://docs.astro.build/en/getting-started/) I like t
 
 I didn't want to spend any time on a simple toggle switch so I opted to grab the one from [Shadcn](https://ui.shadcn.com/docs/dark-mode/astro). I've used it with other frameworks and it works great. The issue I ran into was that when navigating to a new page the theme reset to the default.
 
-
 import BlogImage from "../../components/blog/blog-image.astro";
 
-<BlogImage src="https://res.cloudinary.com/drheg5d7j/image/upload/v1717708102/theme-toggle-issue_udgybe.gif" alt="Theme reverts back to innitial on page navigate" />
+<BlogImage
+  src="https://res.cloudinary.com/drheg5d7j/image/upload/v1717708102/theme-toggle-issue_udgybe.gif"
+  alt="Theme reverts back to innitial on page navigate"
+/>
 
 There are other posts about this and it is mentioned in the Astro docs, but I found that when I applied to solution from the docs it led to a pretty gnarly initial theme flicker. I wanted to share the solution that worked for me, to hopefully save someone else a few minutes.
 
 Here is the script I was using to handle the theme:
 
-``` tsx
+```tsx
 // layout-prose.astro
 <script is:inline>
   const getThemePreference = () => {
@@ -55,11 +57,11 @@ The solution was to add an event listener for `astro:after-swap` that would chec
 
 So, adding this event listener to the script in the layout file fixed the issue for me:
 
-``` ts
-  document.addEventListener('astro:after-swap', function () {
-    if (localStorage.getItem('theme') === 'dark')
-      document.documentElement.classList.toggle('dark', true);
-  });
+```ts
+document.addEventListener("astro:after-swap", function () {
+  if (localStorage.getItem("theme") === "dark")
+    document.documentElement.classList.toggle("dark", true);
+});
 ```
 
 Now the theme persists when navigating between pages. An easy fix, but annoying to debug if you don't know what you're looking for. I hope this helps someone else out there. Cheers!
@@ -68,7 +70,7 @@ Now the theme persists when navigating between pages. An easy fix, but annoying 
 
 Full Code:
 
-``` tsx
+```tsx
 // layout-prose.astro.astro
 ---
 import { ViewTransitions } from 'astro:transitions';
@@ -114,7 +116,7 @@ import { ViewTransitions } from 'astro:transitions';
 </html>
 ```
 
-``` tsx
+```tsx
 // mode-toggle.tsx
 import * as React from "react";
 import { Moon, Sun } from "lucide-react";
@@ -122,38 +124,41 @@ import { Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 export function ModeToggle() {
-	const [theme, setThemeState] = React.useState<
-		"theme-light" | "dark" | "system"
-	>("theme-light");
+  const [theme, setThemeState] = React.useState<
+    "theme-light" | "dark" | "system"
+  >("theme-light");
 
-	React.useEffect(() => {
-		const isDarkMode = document.documentElement.classList.contains("dark");
-		setThemeState(isDarkMode ? "dark" : "theme-light");
-	}, []);
+  React.useEffect(() => {
+    const isDarkMode = document.documentElement.classList.contains("dark");
+    setThemeState(isDarkMode ? "dark" : "theme-light");
+  }, []);
 
-	React.useEffect(() => {
-		const isDark =
-			theme === "dark" ||
-			(theme === "system" &&
-				window.matchMedia("(prefers-color-scheme: dark)").matches);
-		document.documentElement.classList[isDark ? "add" : "remove"]("dark");
-	}, [theme]);
+  React.useEffect(() => {
+    const isDark =
+      theme === "dark" ||
+      (theme === "system" &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches);
+    document.documentElement.classList[isDark ? "add" : "remove"]("dark");
+  }, [theme]);
 
-	return (
-		<Button
-			onClick={() =>
-				setThemeState((prev) => (prev === "dark" ? "theme-light" : "dark"))
-			}
-			variant="ghost"
-			size="icon"
-		>
-			<Sun className="h-[1rem] w-[1rem] rotate-0 scale-100 transition-all 
-      dark:-rotate-90 dark:scale-0" />
-			<Moon className="absolute h-[1rem] w-[1rem] rotate-90 scale-0 
-      transition-all dark:rotate-0 dark:scale-100" />
-			<span className="sr-only">Toggle theme</span>
-		</Button>
-	);
+  return (
+    <Button
+      onClick={() =>
+        setThemeState((prev) => (prev === "dark" ? "theme-light" : "dark"))
+      }
+      variant="ghost"
+      size="icon"
+    >
+      <Sun
+        className="h-[1rem] w-[1rem] rotate-0 scale-100 transition-all
+      dark:-rotate-90 dark:scale-0"
+      />
+      <Moon
+        className="absolute h-[1rem] w-[1rem] rotate-90 scale-0
+      transition-all dark:rotate-0 dark:scale-100"
+      />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
 }
-
 ```

--- a/src/content/posts/el-alquimista.mdx
+++ b/src/content/posts/el-alquimista.mdx
@@ -4,7 +4,7 @@ author: Jack Watters
 description: "Really enjoyed. First book read in Spanish and I loved. Favorite book I've read as an adult."
 pubDate: 2024-03-06
 tags: [books, spanish, travel]
-
+draft: true
 ---
 
 ### Comprehendible input

--- a/src/content/posts/medium-markdown.mdx
+++ b/src/content/posts/medium-markdown.mdx
@@ -1,8 +1,0 @@
----
-title: "Why on earth doesn't medium support markdown"
-author: Jack Watters
-description: ""
-pubDate: 2024-05-14
-tags: [medium, markdown]
-draft: true
----

--- a/src/content/posts/nextdoor-predatory-notifications.mdx
+++ b/src/content/posts/nextdoor-predatory-notifications.mdx
@@ -1,8 +1,0 @@
----
-title: "Nextdoor's predatory notifications"
-author: Jack Watters
-description: ""
-pubDate: 2024-05-14
-tags: [nextdoor]
-draft: true
----

--- a/src/content/posts/pages-router.mdx
+++ b/src/content/posts/pages-router.mdx
@@ -4,9 +4,10 @@ author: Jack Watters
 description: "A look into the Next.js Pages Router and some of the challenges I faced while using it."
 pubDate: 2024-05-14
 tags: [next, routing]
+draft: true
 ---
 
-Having recently completed a project with [Next.js Pages Router](https://nextjs.org/docs/pages), I want to share my experiences and insights. This is not going to be a comparison to [Next.js App Router](https://nextjs.org/docs/app), instead I'll be comparing it to all of the javascript routing solutions I have used, which includes [TanStack Router](https://tanstack.com/router/latest), [React Router](https://reactrouter.com/en/main), [Solid's Router](https://docs.solidjs.com/solid-router) and most recently App Router. Despite its general popularity and adoption, I have found the file-based routing system to be somewhat lacking, even though it is manageable with some effort. My experiences revealed a few pain points that are worth discussing. 
+Having recently completed a project with [Next.js Pages Router](https://nextjs.org/docs/pages), I want to share my experiences and insights. This is not going to be a comparison to [Next.js App Router](https://nextjs.org/docs/app), instead I'll be comparing it to all of the javascript routing solutions I have used, which includes [TanStack Router](https://tanstack.com/router/latest), [React Router](https://reactrouter.com/en/main), [Solid's Router](https://docs.solidjs.com/solid-router) and most recently App Router. Despite its general popularity and adoption, I have found the file-based routing system to be somewhat lacking, even though it is manageable with some effort. My experiences revealed a few pain points that are worth discussing.
 
 #### Centralized vs. File-Based Routing
 
@@ -30,4 +31,4 @@ On the horizon, `React Server Components` (RSC) offer an interesting approach to
 
 While the Pages Router provides a usable and straightforward file-based routing system, it is not without its challenges. The experience could be significantly improved with better layout management, centralized middleware, and more streamlined data-fetching methods. However, it’s worth noting that App Router does a decent job of addressing many of these issues. Features such as improved layout handling and more intuitive data-fetching capabilities offer a promising glimpse into the future of Next.js. Despite the hurdles, my overall journey with Pages Router has been educational. As the ecosystem evolves, I look forward to seeing how Next.js continues to enhance the development experience.
 
-(edit 11/15/24) As much as I usually find Ryan Florence unbearable over twitter, his React Conf speach was great and React Router v7 Looks incredibly promising. I will definitely be giving it a try on my next project. 
+(edit 11/15/24) As much as I usually find Ryan Florence unbearable over twitter, his React Conf speach was great and React Router v7 Looks incredibly promising. I will definitely be giving it a try on my next project.

--- a/src/content/posts/tailwind-prose-text-align.mdx
+++ b/src/content/posts/tailwind-prose-text-align.mdx
@@ -4,24 +4,24 @@ author: Jack Watters
 description: "Learning about text-align: justify.. and how to remove it in Tailwind Typography."
 pubDate: 2024-05-17
 tags: [tailwind]
+draft: true
 ---
 
 import BlogImage from "../../components/blog/blog-image.astro";
 
 TLDR: `prose-p:text-justify` is included in the Astro Recipe and can be removed to fix text spacing issues.
 
-When creating this blog I used a helpful [recipe](https://docs.astro.build/en/recipes/tailwind-rendered-markdown/) from the Astro Docs. It worked great and I though nothing of it, but as I was working on a recent post (shameless self-plug: [Team Send: Informal Team Communication](https://www.jackwatters.dev/blog/team-send)) I noticed the text spacing was off. 
+When creating this blog I used a helpful [recipe](https://docs.astro.build/en/recipes/tailwind-rendered-markdown/) from the Astro Docs. It worked great and I though nothing of it, but as I was working on a recent post (shameless self-plug: [Team Send: Informal Team Communication](https://www.jackwatters.dev/blog/team-send)) I noticed the text spacing was off.
 
-<BlogImage 
+<BlogImage
   src="/blog-images/text-justify.webp"
   alt="Line 3 is too spaced out"
   caption="See line 3"
 />
 
-
 For most text it looks fine - I'd almost say it looks better, but when the spacing is off, it's hard to ignore. The culprit is `text-align: justify;` which I innitially thought was a Tailwind Typography default. I was wrong. It turns out it is included in the Astro recipe. `prose-p:text-justify` is the class causing the issue and can be removed to fix the spacing.
 
-<BlogImage 
+<BlogImage
   src="/blog-images/astro-prose.webp"
   caption="The culprit `prose-p:text-justify`"
 />

--- a/src/content/posts/team-send.mdx
+++ b/src/content/posts/team-send.mdx
@@ -4,13 +4,14 @@ author: "Jack Watters"
 description: "A look into the creation of Team Send amd some of the decisions that went into it."
 pubDate: 2024-05-15
 tags: [coding]
+draft: true
 ---
 
 import BlogImage from "../../components/blog/blog-image.astro";
 
 My senior year at USC I was the housing manager of my fraternity. I only did it so I could bring my dog to the house, but it led me to my first real-world coding application. Among my responsibilities was making sure all live-ins paid their rent on time. I came to learn that it is shockingly (or maybe unshockingly) difficult to get a group of 30 college students to pay rent on time every month.
 
-<BlogImage 
+<BlogImage
   src="/blog-images/chilly.webp"
   alt="My Dog Chilly Outside his 11th Birthday Celebration"
   caption="Chilly's 11th Birthday Tailgate"
@@ -18,41 +19,35 @@ My senior year at USC I was the housing manager of my fraternity. I only did it 
 
 One late night, I realized I could probably create a script that would send text messages to everyone who hadn't paid yet. It wasn't a perfect solution, but I figured I could drown them out with enough messages that they would eventually turn in rent to silence the messages. I was able to put together a script that read the treasurer's spreadsheet and send out a text message to anyone who hadn't paid yet. It was a simple solution, but it worked.
 
-Fast forward a few years and I found myself deciding to turn that script into a web app. I always knew I wanted to build it out, and I finally had the time and skills to do so. Team Send builds on this original idea and enables users to better communicate and coordinate with their informal teams. 
-  
+Fast forward a few years and I found myself deciding to turn that script into a web app. I always knew I wanted to build it out, and I finally had the time and skills to do so. Team Send builds on this original idea and enables users to better communicate and coordinate with their informal teams.
+
 ### Team Send Now
 
-In its current iteration, Team Send is quite simple. Users create a group and add members and from there they can send out messages to the group. Users can send messages via a combination of email, SMS, and GroupMe. Messages can be scheduled to be sent at a later time, on a recurring basis, and include reminders. That's the basic functionality of Team Send. It isn't meant to receice responses or messages, rather serve as a one-way communication tool. 
+In its current iteration, Team Send is quite simple. Users create a group and add members and from there they can send out messages to the group. Users can send messages via a combination of email, SMS, and GroupMe. Messages can be scheduled to be sent at a later time, on a recurring basis, and include reminders. That's the basic functionality of Team Send. It isn't meant to receice responses or messages, rather serve as a one-way communication tool.
 
-(May 2024) The GroupMe integration is a work in progress. I am fine tuning concurency considerations, as the group in Team Send is tied directly to a GroupMe group and changes in one need to be reflected in the other. 
+(May 2024) The GroupMe integration is a work in progress. I am fine tuning concurency considerations, as the group in Team Send is tied directly to a GroupMe group and changes in one need to be reflected in the other.
 
-<BlogImage 
-  src="/blog-images/ts-groups.webp"
-  alt="Team Send Dashboard"
-/>
+<BlogImage src="/blog-images/ts-groups.webp" alt="Team Send Dashboard" />
 
 The main functionality of Team Send currently relies on Twilio for sms, Nodemailer for email, and GroupMe of course GroupMe for GroupMe messaging. I am using Pusher for real-time updates and Qstash for message scheduling. Currently, users are required to use their own Twilio accounts, but I am looking to add a paid tier that will include a Twilio account for users.
 
 Team Send is built using [Next.js Pages Router](https://nextjs.org/docs/pages/). I had previously been doing most of my work in React without a Meta Framework, but I wanted to try out Next, mainly to revisit server-side rendering which I hadn't used since creating a PHP app for a class in college. Considering how many mixed opinions I had seen on [App Router](https://nextjs.org/docs/app/) is I decided Pages Router would be a better introduction. In retrospect, this was a mistake and something I wish I could go back on - I'll expand on this later.
 
-I scaffolded the project using [create-t3-app](https://create.t3.gg/), which I really enjoyed. [tRPC](https://trpc.io/docs) is great and I hope they find a way to integrate it with RSC in a future release. I think RPCs do a great job of abstracting away the API layer and I think it's a great way to build out a project. 
+I scaffolded the project using [create-t3-app](https://create.t3.gg/), which I really enjoyed. [tRPC](https://trpc.io/docs) is great and I hope they find a way to integrate it with RSC in a future release. I think RPCs do a great job of abstracting away the API layer and I think it's a great way to build out a project.
 
 I was between deciding between [Prisma](https://www.prisma.io/docs) and [Drizzle](https://orm.drizzle.team/docs/overview) as an ORM but settled on Prisma because it was much more established and I had used it before. Prisma is fine but I have been using Drizzle on more recent projects and really enjoy its similarity to SQL. That being said Prisma was a completely fine choice for this project and I am excited to see what they are doing with Prisma Accelerate and Pulse. I use postgres on [Railway](https://docs.railway.app/) for all my projects and this one was no different. I have been using a Postgres Docker Image for local development and the combo has been working great.
 
 [Tailwind](https://tailwindcss.com/docs/installation) was an obvious choice - I've been using it for a while and don't plan on changing any time soon. When I began in the React ecosystem I was a huge fan of Styled Components, but I watched a video on them from [Theo (t3․gg)](https://www.youtube.com/@t3dotgg/videos) and his argument for not separating the html from the styles just clicked with me. As much as tailwind can make your code ugly, I think it makes your code much more readable and maintainable.
 
-Rounding out the T3 stack, I used [Auth.js (NextAuthJs)](https://authjs.dev/getting-started) for auth. I've seen similar sentiments on tech Twitter, but Auth.js certainly isn't perfect. I've been using [Clerk](https://clerk.com/docs) on recent projects and while its a breeze to set up, both options have their pros and cons. 
+Rounding out the T3 stack, I used [Auth.js (NextAuthJs)](https://authjs.dev/getting-started) for auth. I've seen similar sentiments on tech Twitter, but Auth.js certainly isn't perfect. I've been using [Clerk](https://clerk.com/docs) on recent projects and while its a breeze to set up, both options have their pros and cons.
 
 Most components are built using [Shadcn](https://ui.shadcn.com/docs). As much as I enjoy building out components from scratch, the built in accessibility features of Shadcn and time saved allow you to focus on the more important parts of your app. I've been using Shadcn for a while and I think it's a great tool for building out components quickly and efficiently. I'm a huge fan of the concept of having the components locally in your app - It made the components incredibly flexible and easy to work with.
 
 ### The Future of Team Send
 
-I am mainly looking to add a few useful integrations specifically Whatsapp. Because Team Send is directed towards more informal teams, I am not currently planning on adding Slack or Discord integrations. I am also looking to add a few more features to the GroupMe integration, such as the ability to add and remove members from the GroupMe group directly from Team Send. That is basically the scope of features planned for now; Team Send is meant to be a utility app and serve a quite specific purpose. 
+I am mainly looking to add a few useful integrations specifically Whatsapp. Because Team Send is directed towards more informal teams, I am not currently planning on adding Slack or Discord integrations. I am also looking to add a few more features to the GroupMe integration, such as the ability to add and remove members from the GroupMe group directly from Team Send. That is basically the scope of features planned for now; Team Send is meant to be a utility app and serve a quite specific purpose.
 
-<BlogImage 
-  src="/blog-images/next-routing.webp"
-  alt="Pages Router Evil??"
-/>
+<BlogImage src="/blog-images/next-routing.webp" alt="Pages Router Evil??" />
 
 ### The Not Fun Stuff
 


### PR DESCRIPTION
# Mark blog posts as drafts

### TL;DR

Mark several blog posts as drafts to prevent them from being published while they're still in development.

### What changed?

- Added `draft: true` to the frontmatter of the following blog posts:
  - `astro-theme-toggle-with-page-transitions.mdx`
  - `el-alquimista.mdx`
  - `pages-router.mdx`
  - `tailwind-prose-text-align.mdx`
  - `team-send.mdx`
- Deleted two empty draft posts:
  - `medium-markdown.mdx`
  - `nextdoor-predatory-notifications.mdx`
- Fixed formatting in several files (indentation, line breaks)

### How to test?

1. Verify that the marked posts don't appear in the published blog list
2. Ensure the deleted draft posts are no longer in the repository
3. Check that the formatting changes don't affect the rendered content

### Why make this change?

These posts are still in development and not ready for public viewing. Marking them as drafts allows continued work on them without exposing incomplete content to site visitors.