### PR TITLE
chore: remove twitter from socials

### DIFF
--- a/src/components/socials/socials.astro
+++ b/src/components/socials/socials.astro
@@ -13,9 +13,9 @@ import SocialBadge from './social-badge.astro';
     <li>
       <SocialBadge href="https://github.com/jackwatters45"> Github</SocialBadge>
     </li>
-    <li>
+    <!-- <li>
       <SocialBadge href="https://x.com/w0tters">Twitter</SocialBadge>
-    </li>
+    </li> -->
     <li>
       <SocialBadge href="https://open.spotify.com/user/jackwatters22">
         Spotify


### PR DESCRIPTION
### TL;DR

Commented out the Twitter social link from the socials component.

### What changed?

- Commented out the Twitter/X social badge in the `socials.astro` component
- Kept GitHub and Spotify links active

### How to test?

1. Navigate to any page that displays the social links
2. Verify that only GitHub and Spotify links are visible
3. Confirm that the Twitter/X link no longer appears

### Why make this change?

Likely removing the Twitter/X social link due to reduced platform usage, rebranding concerns, or a decision to focus on other social platforms. This change streamlines the social links to only display actively maintained profiles.