### PR TITLE
feat: add link to running page

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 # Todo
 
 - [ ] update media + listening
-- [ ] add a link to running page somewhere
 - [ ] start writing
+- [ ] running cursor not working on prod

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -94,5 +94,7 @@ import { LEARNING, LISTENING, READING } from '@/lib/constants';
       }
     </ul>
   </div>
+  <a href="/running" class="">Running Log</a>
+
   <Socials />
 </Layout>


### PR DESCRIPTION
### TL;DR

Added a link to the running page on the about page and updated the TODO list.

### What changed?

- Added a link to the running log page on the about page
- Updated the TODO list:
  - Removed "add a link to running page somewhere" as it's now completed
  - Added a new task "running cursor not working on prod"

### How to test?

1. Navigate to the about page
2. Verify that the "Running Log" link appears at the bottom of the page
3. Confirm the link correctly navigates to the running page

### Why make this change?

To improve site navigation by providing access to the running log from the about page, and to update the TODO list to reflect completed work and new issues that need attention.