### PR TITLE
feat: update watching

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -404,15 +404,27 @@ interface Watching {
 export const WATCHING: Watching = {
   currently: [
     {
-      name: 'The Penguin',
-      link: 'https://play.max.com/show/5756c2bf-36f8-4890-b1f9-ef168f1d8e9c',
+      name: 'Suits',
+      link: 'https://www.disneyplus.com/browse/entity-16ced814-5ed7-4f3c-9b8d-0660a12fc2ee?distributionPartner=google',
     },
     {
-      name: 'Ministerio del Tiempo',
-      link: 'https://www.amazon.com/El-ministerio-del-tiempo-Season/dp/B09JV86JF2',
+      name: 'Anthony Bourdain: Parts Unknown',
+      link: 'https://www.primevideo.com/dp/amzn1.dv.gti.28baa2f2-f652-04f1-77cf-226eb28fc7d8?autoplay=0&ref_=atv_cf_strg_wb',
+    },
+    {
+      name: 'How About Tomorrow?',
+      link: 'https://tomorrow.fm/',
     },
   ],
   podcasts: [
+    {
+      name: 'WAR MODE',
+      link: 'https://open.spotify.com/show/3mPoh0V6S7qwjZDGOUE2BE?si=3017e7a44ef94192',
+    },
+    {
+      name: "Matt and Shane's Secret Podcast",
+      link: 'https://open.spotify.com/show/32p08HngccrVVyugc45Ljp?si=0f04db4a259a495c',
+    },
     {
       name: 'Central - Bukele',
       link: 'https://open.spotify.com/show/5rVz6WZuWQKxWalrPaIRxI',
@@ -473,6 +485,18 @@ export const WATCHING: Watching = {
     },
   ],
   shows: [
+    {
+      name: 'Vice Principals',
+      link: 'https://play.hbomax.com/show/9714271a-a41c-4321-be01-3287f450528e?utm_source=universal_search',
+    },
+    {
+      name: 'The Penguin',
+      link: 'https://play.max.com/show/5756c2bf-36f8-4890-b1f9-ef168f1d8e9c',
+    },
+    {
+      name: 'Ministerio del Tiempo',
+      link: 'https://www.amazon.com/El-ministerio-del-tiempo-Season/dp/B09JV86JF2',
+    },
     {
       name: 'Always Sunny in Philadelphia',
       link: 'https://www.imdb.com/title/tt0472954/',

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,7 +1,7 @@
 ---
 import Socials from '@/components/socials/socials.astro';
 import Layout from '@/layouts/layout-prose.astro';
-import { LEARNING, LISTENING, READING } from '@/lib/constants';
+import { LEARNING, LISTENING, READING, WATCHING } from '@/lib/constants';
 ---
 
 <Layout title="about">
@@ -46,38 +46,6 @@ import { LEARNING, LISTENING, READING } from '@/lib/constants';
     </ul>
   </div>
   <div class="space-y-3">
-    <a href="/watching">Watching</a>
-    <ul class="space-y-2 text-sm text-muted-foreground">
-      <li>
-        <a
-          class="underline underline-offset-4 decoration-muted-foreground hover:underline-offset-[5px] hover:decoration-2 hover:decoration-foreground transition-all"
-          href="https://www.amazon.com/El-ministerio-del-tiempo-Season/dp/B09JV86JF2"
-          >Ministerio del Tiempo</a
-        >
-      </li>
-      <li>
-        <a
-          class="underline underline-offset-4 decoration-muted-foreground hover:underline-offset-[5px] hover:decoration-2 hover:decoration-foreground transition-all"
-          href="https://www.nhl.com/playoffs/2024/bracket">Stanley Cup</a
-        >
-      </li>
-      <li>
-        <a
-          class="underline underline-offset-4 decoration-muted-foreground hover:underline-offset-[5px] hover:decoration-2 hover:decoration-foreground transition-all"
-          href="https://www.adultswim.com/videos/smiling-friends"
-          >Smiling Friends</a
-        >
-      </li>
-      <li>
-        <a
-          class="underline underline-offset-4 decoration-muted-foreground hover:underline-offset-[5px] hover:decoration-2 hover:decoration-foreground transition-all"
-          href="https://open.spotify.com/show/5rVz6WZuWQKxWalrPaIRxI"
-          >Central - Bukele</a
-        >
-      </li>
-    </ul>
-  </div>
-  <div class="space-y-3">
     <a href="/listening">Listening</a>
     <ul class="space-y-2 text-sm text-muted-foreground">
       {
@@ -92,6 +60,21 @@ import { LEARNING, LISTENING, READING } from '@/lib/constants';
           </li>
         ))
       }
+    </ul>
+  </div>
+  <div class="space-y-3">
+    <a href="/watching">Watching</a>
+    <ul class="space-y-2 text-sm text-muted-foreground">
+    {
+      WATCHING.currently.slice(0, 3).map((item) => (
+      <li>
+        <a
+          class="underline underline-offset-4 decoration-muted-foreground hover:underline-offset-[5px] hover:decoration-2 hover:decoration-foreground transition-all"
+          href={item.link}
+          >{item.name}</a
+        >
+      </li>
+      ))}
     </ul>
   </div>
   <a href="/running" class="">Running Log</a>


### PR DESCRIPTION
### TL;DR

Updated the "Currently Watching" section with new shows and podcasts, and improved the About page to dynamically display watching content.

### What changed?

- Updated the `WATCHING.currently` list with new shows: "Suits", "Anthony Bourdain: Parts Unknown", and "How About Tomorrow?"
- Moved previous currently watching items ("The Penguin" and "Ministerio del Tiempo") to the `shows` section
- Added new podcasts: "WAR MODE" and "Matt and Shane's Secret Podcast"
- Added "Vice Principals" to the shows list
- Modified the About page to dynamically display watching content from the constants file instead of using hardcoded links
- Imported the `WATCHING` constant in the About page
- Reordered sections on the About page

### How to test?

1. Visit the About page to verify the watching section now displays the first 3 items from `WATCHING.currently`
2. Check that the links in the watching section are working correctly
3. Navigate to the Watching page to ensure all updated content appears correctly

### Why make this change?

To keep the media consumption lists current and to improve maintainability by using the same data source for both the About page and the Watching page. This eliminates duplication and ensures consistency when updating watched content.