### PR TITLE
feat: add sprinter to listening

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
 # Todo
 
-- [ ] update media + listening
 - [ ] running cursor not working on prod

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -197,9 +197,28 @@ export const LISTENING: Listening = {
         genre: 'Rap',
       },
       {
-        name: 'The Bends',
-        link: 'https://open.spotify.com/artist/2xBejdNon0VS3Egq8he7sb?si=dWhNPj9nQrmR_eQFt3yjEQ',
-        genre: 'Indie Rock',
+        name: 'Demm Deep',
+        link: 'https://open.spotify.com/artist/1MzQYOcw4DMB9ISBhZTa7g?si=1XROGwzXQqW0CrU9DtuKXA',
+        genre: 'House',
+        album: 'Friday Night',
+        albumLink:
+          'https://open.spotify.com/album/4YFmoJXlZyuIYvTgjaf6AX?si=7JoPnm-cTmSCnMcfOc7B3Q',
+      },
+      {
+        name: 'KARMA',
+        link: 'https://open.spotify.com/artist/2CbSXiRcLCT8xjNeoebez9?si=1T6H-k0IRfuKeupB7wYxog',
+        genre: 'House',
+        album: 'Sprinter',
+        albumLink:
+          'https://open.spotify.com/album/1LrwZakIRGBHovLTDBCQSj?si=4NFuUlDZQc2mnfIpab4rLA',
+      },
+      {
+        name: 'Lance Savali',
+        link: 'https://open.spotify.com/artist/3BJfXq3PuHFiHrD6PcfpCd?si=AG7WVgxgTbic1RNKx6XYZA',
+        genre: 'House',
+        album: "TN's",
+        albumLink:
+          'https://open.spotify.com/album/6re07313Esj1OipNfjjUdh?si=WPA7NVilSmS3t-PQrvDMzw',
       },
       {
         name: '49th & Main',
@@ -212,20 +231,9 @@ export const LISTENING: Listening = {
         genre: 'Alternative/Indie',
       },
       {
-        name: 'Demm Deep',
-        link: 'https://open.spotify.com/artist/1MzQYOcw4DMB9ISBhZTa7g?si=1XROGwzXQqW0CrU9DtuKXA',
-        genre: 'House',
-        album: 'Friday Night',
-        albumLink:
-          'https://open.spotify.com/album/4YFmoJXlZyuIYvTgjaf6AX?si=7JoPnm-cTmSCnMcfOc7B3Q',
-      },
-      {
-        name: 'Lance Savali',
-        link: 'https://open.spotify.com/artist/3BJfXq3PuHFiHrD6PcfpCd?si=AG7WVgxgTbic1RNKx6XYZA',
-        genre: 'House',
-        album: "TN's",
-        albumLink:
-          'https://open.spotify.com/album/6re07313Esj1OipNfjjUdh?si=WPA7NVilSmS3t-PQrvDMzw',
+        name: 'The Bends',
+        link: 'https://open.spotify.com/artist/2xBejdNon0VS3Egq8he7sb?si=dWhNPj9nQrmR_eQFt3yjEQ',
+        genre: 'Indie Rock',
       },
     ],
   },


### PR DESCRIPTION
### TL;DR

Updated the music listening section with new artist and reordered existing artists.

### What changed?

- Removed "update media + listening" from TODO list as it's now completed
- Added new artist "KARMA" with their album "Sprinter" to the listening section
- Reordered the existing artists in the listening section (The Bends, 49th & Main, MOTO BANDIT)

### How to test?

1. Check that the TODO list no longer contains the "update media + listening" item
2. Verify that KARMA appears in the listening section with correct links and album information
3. Confirm that the existing artists are displayed in the new order

### Why make this change?

To keep the listening section current with new music discoveries and organize the artist list in a more logical order. This completes the previously planned task of updating the media and listening sections.