### PR TITLE
feat: disable rocket loading for just running

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,7 +1,0 @@
-/*
-  X-Robots-Tag: all
-  Referrer-Policy: strict-origin-when-cross-origin
-
-/*.js
-  Cache-Control: public, max-age=31536000, immutable
-  cf-cache-control: no-transform

--- a/src/layouts/layout-full-screen.astro
+++ b/src/layouts/layout-full-screen.astro
@@ -3,20 +3,15 @@ import CommonHead from '@/components/meta/common-head.astro';
 
 interface Props {
   title?: string;
+  disableRocketLoader?: boolean;
 }
 
-// url should probably do this part but i kinda like the simple path
-const nestedRoutes = ['learning', 'listening', 'reading', 'watching'];
-const pathname = Astro.url.pathname;
-const homeRoute = nestedRoutes.includes(pathname.split('/')[1])
-  ? '/about'
-  : '/';
-
-const { title }: Props = Astro.props;
+const { title, disableRocketLoader }: Props = Astro.props;
 ---
 
 <html lang="en" class="dark">
   <CommonHead title={title} />
+  {disableRocketLoader && <script data-cfasync="false" is:inline></script>}
   <body>
     <main class="h-screen w-screen overflow-x-hidden text-base">
       <slot />

--- a/src/pages/running.astro
+++ b/src/pages/running.astro
@@ -57,7 +57,7 @@ const activitiesWithIndex = activities.map((activity) => {
   };
 });
 ---
-<Layout title='Running'>
+<Layout title='Running' disableRocketLoader={true}>
   <div class="absolute mt-16 md:mt-24 z-50 left-1/2 -translate-x-1/2">
     <div class="container flex flex-col space-y-4 w-[min(640px,100vw)]">
       <a href="/" class="cursor-custom">
@@ -72,6 +72,6 @@ const activitiesWithIndex = activities.map((activity) => {
     </div>
   </div>
     <div class="absolute inset-0">
-      <LineGraph client:only="react" data={activitiesWithIndex} />
+      <LineGraph client:load data={activitiesWithIndex} />
     </div>
 </Layout>


### PR DESCRIPTION
### TL;DR

Improved the running page performance by disabling Cloudflare's Rocket Loader and optimizing React component loading.

### What changed?

- Removed the `public/_headers` file which contained Cloudflare cache and header configurations
- Added a new `disableRocketLoader` prop to the `layout-full-screen.astro` component
- Applied the `disableRocketLoader` prop to the running page
- Changed the React component loading strategy from `client:only="react"` to `client:load` for the LineGraph component

### How to test?

1. Navigate to the running page
2. Verify that the line graph loads correctly
3. Check browser network tab to confirm Rocket Loader is disabled for this page
4. Verify performance is improved compared to previous implementation

### Why make this change?

Cloudflare's Rocket Loader was likely causing issues with the React-based LineGraph component on the running page. By disabling Rocket Loader specifically for this page and changing the client loading strategy, we can ensure the graph renders properly without interference from Cloudflare's optimization features. This targeted approach improves performance while maintaining functionality.