### PR TITLE
chore: remove unused import

### DIFF
--- a/src/pages/listening.astro
+++ b/src/pages/listening.astro
@@ -6,7 +6,6 @@ import ListText from '@/components/list/list-sub-text.astro';
 import { Separator } from '@/components/ui/separator';
 import Layout from '@/layouts/layout-prose.astro';
 import { LISTENING } from '@/lib/constants';
-import Index from './index.astro';
 
 type ListeningArr = Array<{
   title: keyof typeof LISTENING;


### PR DESCRIPTION
### TL;DR

Removed unused import of `Index` from `./index.astro` in the listening page.

### What changed?

Removed a single line that was importing the `Index` component from `./index.astro` which wasn't being used in the listening.astro file.

### How to test?

1. Navigate to the listening page
2. Verify that the page loads correctly without any errors
3. Confirm that all functionality works as expected

### Why make this change?

This change removes an unnecessary import that wasn't being used in the component, which helps to keep the codebase clean and reduces potential confusion. Removing unused imports can also slightly improve build times and bundle size.