### PR TITLE
chore: change deprecated ViewTransition component

### DIFF
--- a/src/components/meta/common-head.astro
+++ b/src/components/meta/common-head.astro
@@ -1,7 +1,7 @@
 ---
 import '../../styles/globals.css';
 
-import { ViewTransitions } from 'astro:transitions';
+import { ClientRouter } from 'astro:transitions';
 import Posthog from '../meta/posthog.astro';
 
 interface Props {
@@ -48,6 +48,6 @@ const formattedTitle = title ? `Jack Watters - ${title}` : 'Jack Watters';
   />
   <meta name="twitter:site" content="@w0tters" />
 
-  <ViewTransitions />
+  <ClientRouter />
   <Posthog />
 </head>


### PR DESCRIPTION
### TL;DR

Replace `ViewTransitions` with `ClientRouter` from Astro transitions

### What changed?

- Updated the import from `ViewTransitions` to `ClientRouter` from 'astro:transitions'
- Replaced the `<ViewTransitions />` component with `<ClientRouter />` in the head section

### How to test?

1. Run the site locally
2. Navigate between pages to ensure transitions still work properly
3. Verify that client-side routing functions as expected

### Why make this change?

The Astro framework has updated its API for handling client-side transitions. `ClientRouter` is the newer component that replaces `ViewTransitions`, providing the same functionality with potentially improved performance or additional features.